### PR TITLE
Settings update for Turku

### DIFF
--- a/high_contrast_map-w-sprites.json
+++ b/high_contrast_map-w-sprites.json
@@ -9,7 +9,7 @@
     }
   },
   "sprite": "/styles/high-contrast-map-layer/sprite",
-  "glyphs": "/fonts/{fontstack}/{range}.pbf",
+  "glyphs": "{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",

--- a/high_contrast_map-w-sprites.json
+++ b/high_contrast_map-w-sprites.json
@@ -5,10 +5,10 @@
   "sources": {
     "openmaptiles": {
       "type": "vector",
-      "url": "https://maptiles.turku.fi/data/finland.json"
+      "url": "mbtiles://tiles.mbtiles"
     }
   },
-  "sprite": "/data/styles/high-contrast-map-layer/sprite",
+  "sprite": "/styles/high-contrast-map-layer/sprite",
   "glyphs": "https://maptiles.turku.fi/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {

--- a/high_contrast_map-w-sprites.json
+++ b/high_contrast_map-w-sprites.json
@@ -707,7 +707,7 @@
         "text-offset": [0, 0.5],
         "text-size": {"stops": [[11, 20], [12, 30]]},
         "visibility": "visible",
-        "text-transform": "uppercase"
+        "text-transform": "none"
       },
       "paint": {
         "text-color": "rgba(0, 0, 0, 1)",
@@ -757,7 +757,7 @@
         "text-font": ["Lato Regular"],
         "text-max-width": 6,
         "visibility": "visible",
-        "text-transform": "uppercase",
+        "text-transform": "none",
         "text-size": {"stops": [[6, 14], [12, 25], [15, 30], [17, 35]]}
       },
       "paint": {
@@ -778,7 +778,7 @@
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": ["Lato Regular"],
         "text-max-width": 10,
-        "text-transform": "uppercase",
+        "text-transform": "none",
         "text-size": {"stops": [[3, 20], [8, 30]]}
       },
       "paint": {

--- a/high_contrast_map-w-sprites.json
+++ b/high_contrast_map-w-sprites.json
@@ -9,7 +9,7 @@
     }
   },
   "sprite": "/styles/high-contrast-map-layer/sprite",
-  "glyphs": "https://maptiles.turku.fi/fonts/{fontstack}/{range}.pbf",
+  "glyphs": "/fonts/{fontstack}/{range}.pbf",
   "layers": [
     {
       "id": "background",

--- a/high_contrast_map.json
+++ b/high_contrast_map.json
@@ -5,7 +5,7 @@
   "sources": {
     "openmaptiles": {
       "type": "vector",
-      "url": "https://maptiles.turku.fi/data/finland.json"
+      "url": "/data/finland.json"
     }
   },
   "glyphs": "{fontstack}/{range}.pbf",

--- a/high_contrast_map.json
+++ b/high_contrast_map.json
@@ -669,7 +669,7 @@
         "text-offset": [0, 0.5],
         "text-size": {"stops": [[11, 20], [12, 30]]},
         "visibility": "visible",
-        "text-transform": "uppercase"
+        "text-transform": "none"
       },
       "paint": {
         "text-color": "rgba(0, 0, 0, 1)",
@@ -719,7 +719,7 @@
         "text-font": ["Lato Regular"],
         "text-max-width": 6,
         "visibility": "visible",
-        "text-transform": "uppercase",
+        "text-transform": "none",
         "text-size": {"stops": [[6, 14], [12, 25], [15, 30], [17, 35]]}
       },
       "paint": {
@@ -740,7 +740,7 @@
         "text-field": "{name:latin}\n{name:nonlatin}",
         "text-font": ["Lato Regular"],
         "text-max-width": 10,
-        "text-transform": "uppercase",
+        "text-transform": "none",
         "text-size": {"stops": [[3, 20], [8, 30]]}
       },
       "paint": {


### PR DESCRIPTION
# Update map layer styles

## Update styles so that area names are rendered without text-transform (uppercase) style. Ensure that URL values of maptiles are correct for Turku. 

-----------------------------------------------------------------------------------------------
### Breakdown:

#### Update styles
1. high_contrast_map-w-sprites.json
     * Update text styles and URL values.
  
2. high_contrast_map.json
     * Update text styles and URL values.

